### PR TITLE
Upgrade auth patterns to align with Backend-Service / wxyc-shared

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ BETTER_AUTH_URL=https://api.wxyc.org/auth
 NEXT_PUBLIC_BETTER_AUTH_URL=https://api.wxyc.org/auth
 # JWKS endpoint for JWT verification
 BETTER_AUTH_JWKS_URL=https://api.wxyc.org/auth/jwks
+# JWT claim validation (required in production, optional in development)
+BETTER_AUTH_ISSUER=https://api.wxyc.org
+BETTER_AUTH_AUDIENCE=https://api.wxyc.org
 
 # Analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/app/api/signed-url/route.ts
+++ b/app/api/signed-url/route.ts
@@ -3,7 +3,7 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { archiveConfigs, getDateRange } from "@/config/archive";
 import { verifyAuthHeader } from "@/lib/jwt-utils";
-import { isDJRole } from "@wxyc/shared/auth-client";
+import { roleToAuthorization, Authorization } from "@wxyc/shared/auth-client/auth";
 
 let s3Client: S3Client | null = null;
 try {
@@ -58,7 +58,8 @@ export async function POST(request: Request) {
 
   // Determine if user has DJ-level access
   const hasDJAccess =
-    verifyResult.authenticated && isDJRole(verifyResult.role);
+    verifyResult.authenticated &&
+    roleToAuthorization(verifyResult.role) >= Authorization.DJ;
 
   // Get appropriate date range based on authentication
   const config = hasDJAccess ? archiveConfigs.dj : archiveConfigs.default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3861,7 +3861,6 @@
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -3869,7 +3868,6 @@
     },
     "node_modules/@cloudflare/unenv-preset": {
       "version": "2.12.0",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -3883,7 +3881,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -3894,7 +3891,6 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -4638,7 +4634,6 @@
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5915,7 +5910,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.58.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.1"
@@ -5929,7 +5924,6 @@
     },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -5937,7 +5931,6 @@
     },
     "node_modules/@poppinss/dumper": {
       "version": "0.6.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -5947,7 +5940,6 @@
     },
     "node_modules/@poppinss/dumper/node_modules/supports-color": {
       "version": "10.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5958,7 +5950,6 @@
     },
     "node_modules/@poppinss/exception": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
@@ -6874,7 +6865,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6888,7 +6878,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6900,7 +6889,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6914,7 +6902,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6928,7 +6915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6942,7 +6928,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6956,7 +6941,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6970,7 +6954,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6984,7 +6967,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6998,7 +6980,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7012,7 +6993,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7026,7 +7006,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7040,7 +7019,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7054,7 +7032,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7068,7 +7045,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7082,7 +7058,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7096,7 +7071,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7110,7 +7084,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7124,7 +7097,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7138,7 +7110,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7152,7 +7123,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7166,7 +7136,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7180,7 +7149,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7194,7 +7162,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7208,7 +7175,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7222,7 +7188,6 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7863,7 +7828,6 @@
     },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.14",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
@@ -8278,7 +8242,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -8287,12 +8251,12 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/glob": {
@@ -8342,7 +8306,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8350,7 +8314,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8365,14 +8329,14 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8951,7 +8915,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -8967,7 +8931,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.0.18",
@@ -8992,7 +8956,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.0.3"
@@ -9003,7 +8967,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.0.18",
@@ -9015,7 +8979,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.0.18",
@@ -9028,7 +8992,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -9036,7 +9000,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.0.18",
@@ -9047,8 +9011,8 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/WXYC/wxyc-shared.git#1bc51192ff385f78204b634ad91e5b9171d877ab",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/WXYC/wxyc-shared.git#126b71eb4a14eacd23cd39a440e9b74c43ad6798",
       "license": "MIT",
       "dependencies": {
         "better-auth": "^1.4.9",
@@ -9383,7 +9347,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9593,7 +9557,6 @@
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -9775,7 +9738,7 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10101,7 +10064,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -10314,7 +10277,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -10526,7 +10488,6 @@
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -10641,7 +10602,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -11203,7 +11164,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -11265,7 +11226,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -11585,7 +11546,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11849,7 +11809,7 @@
       "version": "20.4.0",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.4.0.tgz",
       "integrity": "sha512-RDeQm3dT9n0A5f/TszjUmNCLEuPnMGv3Tv4BmNINebz/h17PA6LMBcxJ5FrcqltNBMh9jA/8ufgDdBYUdBt+eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
@@ -11867,7 +11827,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11880,7 +11840,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12578,7 +12538,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -12671,7 +12631,6 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12714,7 +12673,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.30.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -12747,7 +12706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12766,7 +12724,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12787,7 +12744,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12808,7 +12764,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12829,7 +12784,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12850,7 +12804,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12871,7 +12824,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12892,7 +12844,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12913,7 +12864,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12934,7 +12884,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12955,7 +12904,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13291,7 +13239,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -13853,7 +13801,7 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -14074,7 +14022,6 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -14106,7 +14053,7 @@
     },
     "node_modules/playwright": {
       "version": "1.58.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.1"
@@ -14123,7 +14070,7 @@
     },
     "node_modules/playwright-core": {
       "version": "1.58.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14136,7 +14083,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14157,7 +14103,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14672,7 +14618,7 @@
     },
     "node_modules/rollup": {
       "version": "4.57.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -14823,7 +14769,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.3",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14957,7 +14902,6 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15081,7 +15025,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -15190,7 +15134,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -15204,7 +15148,7 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -15486,7 +15430,6 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -15567,12 +15510,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15580,7 +15523,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -15595,7 +15538,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -15802,7 +15745,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15855,7 +15797,6 @@
     },
     "node_modules/undici": {
       "version": "7.19.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -15869,7 +15810,6 @@
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -16041,7 +15981,7 @@
     },
     "node_modules/vite": {
       "version": "7.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -16114,7 +16054,7 @@
     },
     "node_modules/vitest": {
       "version": "4.0.18",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/expect": "4.0.18",
@@ -16297,7 +16237,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -16322,7 +16262,6 @@
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.61.1.tgz",
       "integrity": "sha512-hfYQ16VLPkNi8xE1/V3052S2stM5e+vq3Idpt83sXoDC3R7R1CLgMkK6M6+Qp3G+9GVDNyHCkvohMPdfFTaD4Q==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
@@ -16360,7 +16299,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16375,7 +16313,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16392,7 +16329,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16409,7 +16345,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16426,7 +16361,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16438,7 +16372,6 @@
     },
     "node_modules/wrangler/node_modules/miniflare": {
       "version": "4.20260128.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -16457,7 +16390,6 @@
     },
     "node_modules/wrangler/node_modules/workerd": {
       "version": "1.20260128.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16476,7 +16408,6 @@
     },
     "node_modules/wrangler/node_modules/ws": {
       "version": "8.18.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16496,7 +16427,6 @@
     },
     "node_modules/wrangler/node_modules/youch": {
       "version": "4.1.0-beta.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -16612,7 +16542,7 @@
     },
     "node_modules/ws": {
       "version": "8.19.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16746,7 +16676,6 @@
     },
     "node_modules/youch-core": {
       "version": "0.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",


### PR DESCRIPTION
## Summary
- Replace ad-hoc `isDJRole()` checks with the hierarchical `Authorization` enum from wxyc-shared
- Add JWT issuer/audience claim validation (soft degradation when env vars are missing)
- Type `role` fields as `WXYCRole` instead of `string` throughout
- Server-side code imports from `@wxyc/shared/auth-client/auth` (pure utilities, no React)

Closes #18

## Test plan
- [x] `npm run test` -- all 143 tests pass across 9 test files
- [x] `npx tsc --noEmit` -- type checking passes
- [ ] Verify `BETTER_AUTH_ISSUER` and `BETTER_AUTH_AUDIENCE` are set in production env
- [ ] Smoke test: DJ login and archive playback still work