### PR TITLE
Fix GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,25 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx tsc --noEmit
+
+      - run: npm test
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v6
 
@@ -27,35 +44,8 @@ jobs:
           NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
 
-      - name: Upload build artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v6
-        with:
-          name: open-next-build
-          path: .open-next/
-          retention-days: 1
-
-  deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: open-next-build
-          path: .open-next/
-
       - name: Deploy to Cloudflare Workers
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Deployment is handled by the GitHub Actions workflow in `.github/workflows/deplo
 
 ### How it works
 
-- **Pull requests** run the `build` job to verify the OpenNext/Cloudflare Workers build succeeds.
-- **Pushes to `main`** run `build`, then `deploy` which uses Wrangler to deploy the built output to Cloudflare Workers.
+- **Pull requests** run `test` (type check + unit tests) and `build-and-deploy` (OpenNext build) to verify everything works.
+- **Pushes to `main`** additionally deploy the built output to Cloudflare Workers via Wrangler.
 
 ### Required GitHub configuration
 
@@ -52,3 +52,5 @@ These are set directly on the Cloudflare Worker (via `wrangler secret put` or th
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `BETTER_AUTH_JWKS_URL`
+- `BETTER_AUTH_ISSUER`
+- `BETTER_AUTH_AUDIENCE`

--- a/lib/__tests__/jwt-utils.test.ts
+++ b/lib/__tests__/jwt-utils.test.ts
@@ -29,7 +29,8 @@ describe("jwt-utils", () => {
       vi.mocked(jose.jwtVerify).mockResolvedValue({
         payload: mockPayload,
         protectedHeader: { alg: "RS256" },
-      } as jose.JWTVerifyResult & jose.ResolvedKey);
+        key: new Uint8Array(),
+      } as unknown as jose.JWTVerifyResult & jose.ResolvedKey);
 
       const result = await verifyToken("valid-token");
 
@@ -42,7 +43,7 @@ describe("jwt-utils", () => {
 
     it("should return authenticated false for expired token", async () => {
       vi.mocked(jose.jwtVerify).mockRejectedValue(
-        new jose.errors.JWTExpired("Token expired")
+        new jose.errors.JWTExpired("Token expired", {})
       );
 
       const result = await verifyToken("expired-token");
@@ -68,7 +69,7 @@ describe("jwt-utils", () => {
 
     it("should return authenticated false for claim validation failure", async () => {
       vi.mocked(jose.jwtVerify).mockRejectedValue(
-        new jose.errors.JWTClaimValidationFailed("Claim validation failed")
+        new jose.errors.JWTClaimValidationFailed("Claim validation failed", {})
       );
 
       const result = await verifyToken("invalid-claims-token");
@@ -88,7 +89,8 @@ describe("jwt-utils", () => {
       vi.mocked(jose.jwtVerify).mockResolvedValue({
         payload: mockPayload,
         protectedHeader: { alg: "RS256" },
-      } as jose.JWTVerifyResult & jose.ResolvedKey);
+        key: new Uint8Array(),
+      } as unknown as jose.JWTVerifyResult & jose.ResolvedKey);
 
       const result = await verifyToken("valid-token-no-role");
 
@@ -137,7 +139,8 @@ describe("jwt-utils", () => {
       vi.mocked(jose.jwtVerify).mockResolvedValue({
         payload: mockPayload,
         protectedHeader: { alg: "RS256" },
-      } as jose.JWTVerifyResult & jose.ResolvedKey);
+        key: new Uint8Array(),
+      } as unknown as jose.JWTVerifyResult & jose.ResolvedKey);
 
       const result = await verifyAuthHeader("Bearer valid-token");
 


### PR DESCRIPTION
## Summary

- Consolidate two-job workflow (build + deploy) into a single `build-and-deploy` job, fixing the `upload-artifact` hidden-file bug (`.open-next/` starts with `.` and was silently skipped)
- Add a `test` job that runs `tsc --noEmit` and `npm test` before the build
- Add `BETTER_AUTH_ISSUER` and `BETTER_AUTH_AUDIENCE` to the runtime secrets docs in README

Closes #20

## Test plan

- [ ] CI workflow runs: `test` job passes (type check + unit tests)
- [ ] CI workflow runs: `build-and-deploy` job builds successfully
- [ ] After merge to main, deploy step runs and deploys to Cloudflare Workers
- [ ] Disable Cloudflare Pages auto-build via dashboard after merge