### PR TITLE
Add playlist data layer for archive playlist integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ NEXT_PUBLIC_BETTER_AUTH_URL=https://api.wxyc.org/auth
 # JWKS endpoint for JWT verification
 BETTER_AUTH_JWKS_URL=https://api.wxyc.org/auth/jwks
 
+# Playlist data sources (server-side only)
+TUBAFRENZY_PROXY_URL=https://wxyc-proxy-production.up.railway.app/playlists
+LIBRARY_METADATA_URL=https://library-metadata-lookup-production.up.railway.app/api/v1
+
 # Analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=

--- a/app/api/playlist/__tests__/route.test.ts
+++ b/app/api/playlist/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GET } from "../route";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  global.fetch = mockFetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost:3000/api/playlist");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new Request(url.toString());
+}
+
+describe("GET /api/playlist", () => {
+  it("returns 400 when date is missing", async () => {
+    const response = await GET(makeRequest({ hour: "15" }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Missing required parameters");
+  });
+
+  it("returns 400 when hour is missing", async () => {
+    const response = await GET(makeRequest({ date: "2024-01-15" }));
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Missing required parameters");
+  });
+
+  it("returns 400 for invalid date format", async () => {
+    const response = await GET(
+      makeRequest({ date: "01/15/2024", hour: "15" })
+    );
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Invalid date format");
+  });
+
+  it("returns 400 for invalid hour", async () => {
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "25" })
+    );
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Invalid hour");
+  });
+
+  it("returns 400 for non-numeric hour", async () => {
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "abc" })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("fetches and maps entries from tubafrenzy", async () => {
+    const tubafrenzyResponse = [
+      {
+        id: 100,
+        chronOrderID: 456100,
+        hour: 1705352400000,
+        timeCreated: 1705352520000,
+        entryType: "playcut",
+        artistName: "Autechre",
+        songTitle: "VI Scose Poise",
+        releaseTitle: "Confield",
+        labelName: "Warp",
+        rotation: "false",
+        request: "false",
+      },
+      {
+        id: 101,
+        chronOrderID: 456101,
+        hour: 1705352400000,
+        timeCreated: 1705356000000,
+        entryType: "breakpoint",
+        label: "3:00 AM",
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(tubafrenzyResponse),
+    });
+
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "15" })
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.entries).toHaveLength(2);
+    expect(data.radioHourEpoch).toBeTypeOf("number");
+
+    // First entry is a playcut
+    expect(data.entries[0].entryType).toBe("playcut");
+    expect(data.entries[0].artistName).toBe("Autechre");
+    expect(data.entries[0].songTitle).toBe("VI Scose Poise");
+    expect(data.entries[0].offsetSeconds).toBeTypeOf("number");
+    expect(data.entries[0].offsetSeconds).toBeGreaterThanOrEqual(0);
+
+    // Second entry is a breakpoint
+    expect(data.entries[1].entryType).toBe("breakpoint");
+    expect(data.entries[1].label).toBe("3:00 AM");
+  });
+
+  it("returns empty entries when tubafrenzy returns empty array", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "15" })
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.entries).toHaveLength(0);
+  });
+
+  it("returns 502 when tubafrenzy returns an error", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "15" })
+    );
+    expect(response.status).toBe(502);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("returns 502 when fetch throws", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const response = await GET(
+      makeRequest({ date: "2024-01-15", hour: "15" })
+    );
+    expect(response.status).toBe(502);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/api/playlist/route.ts
+++ b/app/api/playlist/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { computeRadioHourEpoch } from "@/lib/utils";
+import {
+  type TubafrenzyEntry,
+  type PlaylistResponse,
+  mapTubafrenzyEntry,
+} from "@/lib/types/playlist";
+
+const TUBAFRENZY_PROXY_URL =
+  process.env.TUBAFRENZY_PROXY_URL ||
+  "https://wxyc-proxy-production.up.railway.app/playlists";
+
+/**
+ * GET /api/playlist?date=YYYY-MM-DD&hour=HH
+ *
+ * Fetches flowsheet entries for a specific date and hour from tubafrenzy,
+ * computes playhead offsets, and returns structured playlist data.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get("date");
+  const hourStr = searchParams.get("hour");
+
+  if (!date || !hourStr) {
+    return NextResponse.json(
+      { error: "Missing required parameters: date and hour" },
+      { status: 400 }
+    );
+  }
+
+  // Validate date format
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json(
+      { error: "Invalid date format. Expected YYYY-MM-DD" },
+      { status: 400 }
+    );
+  }
+
+  const hour = parseInt(hourStr, 10);
+  if (isNaN(hour) || hour < 0 || hour > 23) {
+    return NextResponse.json(
+      { error: "Invalid hour. Expected 0-23" },
+      { status: 400 }
+    );
+  }
+
+  // Compute the radioHour epoch ms in Eastern timezone
+  const radioHourEpoch = computeRadioHourEpoch(date, hour);
+
+  try {
+    const response = await fetch(
+      `${TUBAFRENZY_PROXY_URL}/hourlyEntries?radioHour=${radioHourEpoch}`,
+      { next: { revalidate: 60 } }
+    );
+
+    if (!response.ok) {
+      console.error(
+        `Tubafrenzy returned ${response.status} for radioHour=${radioHourEpoch}`
+      );
+      return NextResponse.json(
+        { error: "Failed to fetch playlist data" },
+        { status: 502 }
+      );
+    }
+
+    const rawEntries: TubafrenzyEntry[] = await response.json();
+
+    const entries = rawEntries.map((entry) =>
+      mapTubafrenzyEntry(entry, radioHourEpoch)
+    );
+
+    const result: PlaylistResponse = {
+      entries,
+      radioHourEpoch,
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching playlist:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch playlist data" },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -6,6 +6,8 @@ import {
   getHourLabel,
   createTimestamp,
   getArchiveUrl,
+  computeRadioHourEpoch,
+  computeEntryOffsetSeconds,
 } from "../utils";
 
 describe("cn", () => {
@@ -203,5 +205,74 @@ describe("getArchiveUrl", () => {
     await expect(getArchiveUrl(date, 14, null)).rejects.toThrow("Network error");
     expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
+  });
+});
+
+describe("computeRadioHourEpoch", () => {
+  it("returns epoch ms for an EST date (winter)", () => {
+    // Jan 15 2024 at 3:00 PM EST = Jan 15 2024 at 20:00 UTC
+    const result = computeRadioHourEpoch("2024-01-15", 15);
+    const date = new Date(result);
+    // Verify the UTC hour is 20 (15 + 5 for EST)
+    expect(date.getUTCHours()).toBe(20);
+    expect(date.getUTCFullYear()).toBe(2024);
+    expect(date.getUTCMonth()).toBe(0); // January
+    expect(date.getUTCDate()).toBe(15);
+    expect(date.getUTCMinutes()).toBe(0);
+    expect(date.getUTCSeconds()).toBe(0);
+  });
+
+  it("returns epoch ms for an EDT date (summer)", () => {
+    // Jul 15 2024 at 3:00 PM EDT = Jul 15 2024 at 19:00 UTC
+    const result = computeRadioHourEpoch("2024-07-15", 15);
+    const date = new Date(result);
+    expect(date.getUTCHours()).toBe(19);
+    expect(date.getUTCFullYear()).toBe(2024);
+    expect(date.getUTCMonth()).toBe(6); // July
+    expect(date.getUTCDate()).toBe(15);
+  });
+
+  it("handles midnight correctly", () => {
+    // Jan 15 2024 at midnight EST = Jan 15 2024 at 05:00 UTC
+    const result = computeRadioHourEpoch("2024-01-15", 0);
+    const date = new Date(result);
+    expect(date.getUTCHours()).toBe(5);
+    expect(date.getUTCDate()).toBe(15);
+  });
+
+  it("handles late night hours crossing day boundary in UTC", () => {
+    // Jan 15 2024 at 11:00 PM EST = Jan 16 2024 at 04:00 UTC
+    const result = computeRadioHourEpoch("2024-01-15", 23);
+    const date = new Date(result);
+    expect(date.getUTCHours()).toBe(4);
+    expect(date.getUTCDate()).toBe(16);
+  });
+});
+
+describe("computeEntryOffsetSeconds", () => {
+  const radioHourEpoch = 1700000000000;
+
+  it("computes offset for an entry within the hour", () => {
+    const entryTime = radioHourEpoch + 120000; // 2 minutes in
+    expect(computeEntryOffsetSeconds(entryTime, radioHourEpoch)).toBe(120);
+  });
+
+  it("returns 0 for an entry at the start of the hour", () => {
+    expect(computeEntryOffsetSeconds(radioHourEpoch, radioHourEpoch)).toBe(0);
+  });
+
+  it("clamps negative offsets to 0", () => {
+    const entryTime = radioHourEpoch - 5000; // 5 seconds before the hour
+    expect(computeEntryOffsetSeconds(entryTime, radioHourEpoch)).toBe(0);
+  });
+
+  it("clamps offsets beyond 3600 seconds", () => {
+    const entryTime = radioHourEpoch + 4000000; // well past the hour
+    expect(computeEntryOffsetSeconds(entryTime, radioHourEpoch)).toBe(3600);
+  });
+
+  it("handles fractional seconds by flooring", () => {
+    const entryTime = radioHourEpoch + 1500; // 1.5 seconds
+    expect(computeEntryOffsetSeconds(entryTime, radioHourEpoch)).toBe(1);
   });
 });

--- a/lib/hooks/use-playlist.ts
+++ b/lib/hooks/use-playlist.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type {
+  ArchivePlaylistEntry,
+  PlaylistResponse,
+} from "@/lib/types/playlist";
+
+export interface UsePlaylistResult {
+  entries: ArchivePlaylistEntry[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetches and manages playlist data for the selected date and hour.
+ * Re-fetches when date or hour changes while archive is selected.
+ */
+export function usePlaylist(
+  selectedDate: Date | null,
+  selectedHour: number | null,
+  archiveSelected: boolean
+): UsePlaylistResult {
+  const [entries, setEntries] = useState<ArchivePlaylistEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchPlaylist = useCallback(
+    async (date: Date, hour: number) => {
+      // Abort any in-flight request
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setIsLoading(true);
+      setError(null);
+
+      const dateStr = `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
+
+      try {
+        const response = await fetch(
+          `/api/playlist?date=${dateStr}&hour=${hour}`,
+          { signal: controller.signal }
+        );
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(
+            data.error || `Failed to fetch playlist (${response.status})`
+          );
+        }
+
+        const data: PlaylistResponse = await response.json();
+        setEntries(data.entries);
+        setError(null);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return; // Request was cancelled, don't update state
+        }
+        console.error("Error fetching playlist:", err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load playlist"
+        );
+        setEntries([]);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!archiveSelected || selectedDate === null || selectedHour === null) {
+      setEntries([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    fetchPlaylist(selectedDate, selectedHour);
+
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, [selectedDate, selectedHour, archiveSelected, fetchPlaylist]);
+
+  return { entries, isLoading, error };
+}

--- a/lib/types/__tests__/playlist.test.ts
+++ b/lib/types/__tests__/playlist.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapTubafrenzyEntry,
+  type TubafrenzyEntry,
+} from "../playlist";
+
+const RADIO_HOUR = 1700000000000;
+
+describe("mapTubafrenzyEntry", () => {
+  it("maps a playcut entry with correct offset and fields", () => {
+    const entry: TubafrenzyEntry = {
+      id: 100,
+      chronOrderID: 5001,
+      hour: RADIO_HOUR,
+      timeCreated: RADIO_HOUR + 120000, // 2 minutes in
+      entryType: "playcut",
+      artistName: "Juana Molina",
+      songTitle: "la paradoja",
+      releaseTitle: "DOGA",
+      labelName: "Sonamos",
+      rotation: "true",
+      request: "false",
+    };
+
+    const result = mapTubafrenzyEntry(entry, RADIO_HOUR);
+
+    expect(result.id).toBe(100);
+    expect(result.entryType).toBe("playcut");
+    expect(result.offsetSeconds).toBe(120);
+    expect(result.artistName).toBe("Juana Molina");
+    expect(result.songTitle).toBe("la paradoja");
+    expect(result.releaseTitle).toBe("DOGA");
+    expect(result.labelName).toBe("Sonamos");
+    expect(result.rotation).toBe(true);
+    expect(result.request).toBe(false);
+  });
+
+  it("maps a breakpoint entry with label", () => {
+    const entry: TubafrenzyEntry = {
+      id: 101,
+      chronOrderID: 5002,
+      hour: RADIO_HOUR,
+      timeCreated: RADIO_HOUR + 3600000,
+      entryType: "breakpoint",
+      label: "3:00 AM",
+    };
+
+    const result = mapTubafrenzyEntry(entry, RADIO_HOUR);
+
+    expect(result.id).toBe(101);
+    expect(result.entryType).toBe("breakpoint");
+    expect(result.label).toBe("3:00 AM");
+    expect(result.artistName).toBeUndefined();
+  });
+
+  it("maps a talkset entry", () => {
+    const entry: TubafrenzyEntry = {
+      id: 102,
+      chronOrderID: 5003,
+      hour: RADIO_HOUR,
+      timeCreated: RADIO_HOUR + 300000,
+      entryType: "talkset",
+    };
+
+    const result = mapTubafrenzyEntry(entry, RADIO_HOUR);
+
+    expect(result.id).toBe(102);
+    expect(result.entryType).toBe("talkset");
+    expect(result.offsetSeconds).toBe(300);
+    expect(result.artistName).toBeUndefined();
+  });
+
+  it("clamps negative offset to 0", () => {
+    const entry: TubafrenzyEntry = {
+      id: 103,
+      chronOrderID: 5004,
+      hour: RADIO_HOUR,
+      timeCreated: RADIO_HOUR - 5000,
+      entryType: "playcut",
+      artistName: "Test",
+      songTitle: "Song",
+    };
+
+    const result = mapTubafrenzyEntry(entry, RADIO_HOUR);
+    expect(result.offsetSeconds).toBe(0);
+  });
+
+  it("defaults missing playcut fields to empty strings", () => {
+    const entry: TubafrenzyEntry = {
+      id: 104,
+      chronOrderID: 5005,
+      hour: RADIO_HOUR,
+      timeCreated: RADIO_HOUR + 60000,
+      entryType: "playcut",
+    };
+
+    const result = mapTubafrenzyEntry(entry, RADIO_HOUR);
+    expect(result.artistName).toBe("");
+    expect(result.songTitle).toBe("");
+    expect(result.releaseTitle).toBe("");
+    expect(result.labelName).toBe("");
+    expect(result.rotation).toBe(false);
+    expect(result.request).toBe(false);
+  });
+});

--- a/lib/types/playlist.ts
+++ b/lib/types/playlist.ts
@@ -1,0 +1,86 @@
+/**
+ * Raw entry from the tubafrenzy /hourlyEntries endpoint.
+ * Field names match tubafrenzy's Java/JSON conventions (camelCase).
+ */
+export interface TubafrenzyEntry {
+  id: number;
+  chronOrderID: number;
+  /** Radio hour as epoch milliseconds */
+  hour: number;
+  /** Entry creation time as epoch milliseconds */
+  timeCreated: number;
+  entryType: "playcut" | "talkset" | "breakpoint";
+  /** Playcut fields (present when entryType === "playcut") */
+  artistName?: string;
+  songTitle?: string;
+  releaseTitle?: string;
+  labelName?: string;
+  rotation?: string;
+  request?: string;
+  /** Breakpoint label (present when entryType === "breakpoint") */
+  label?: string;
+}
+
+/**
+ * A playlist entry enriched with computed offset and optional artwork.
+ * Used on the client side for rendering and playhead sync.
+ */
+export interface ArchivePlaylistEntry {
+  id: number;
+  entryType: "playcut" | "talkset" | "breakpoint";
+  /** Seconds into the hour (for playhead sync) */
+  offsetSeconds: number;
+  /** Playcut fields */
+  artistName?: string;
+  songTitle?: string;
+  releaseTitle?: string;
+  labelName?: string;
+  rotation?: boolean;
+  request?: boolean;
+  /** Breakpoint label */
+  label?: string;
+  /** Album artwork URL from library-metadata-lookup (added in PR 4) */
+  artworkUrl?: string | null;
+  /** Whether artwork is currently being fetched */
+  artworkLoading?: boolean;
+}
+
+/**
+ * Response shape from GET /api/playlist
+ */
+export interface PlaylistResponse {
+  entries: ArchivePlaylistEntry[];
+  radioHourEpoch: number;
+}
+
+/**
+ * Maps a raw tubafrenzy entry to an ArchivePlaylistEntry.
+ */
+export function mapTubafrenzyEntry(
+  entry: TubafrenzyEntry,
+  radioHourEpoch: number
+): ArchivePlaylistEntry {
+  const offsetSeconds = Math.max(
+    0,
+    Math.floor((entry.timeCreated - radioHourEpoch) / 1000)
+  );
+
+  const base: ArchivePlaylistEntry = {
+    id: entry.id,
+    entryType: entry.entryType,
+    offsetSeconds,
+  };
+
+  if (entry.entryType === "playcut") {
+    base.artistName = entry.artistName ?? "";
+    base.songTitle = entry.songTitle ?? "";
+    base.releaseTitle = entry.releaseTitle ?? "";
+    base.labelName = entry.labelName ?? "";
+    base.rotation = entry.rotation === "true";
+    base.request = entry.request === "true";
+  } else if (entry.entryType === "breakpoint") {
+    base.label = entry.label;
+  }
+
+  return base;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -83,6 +83,52 @@ export async function getArchiveUrl(
   }
 }
 
+/**
+ * Compute the epoch milliseconds for a radio hour in America/New_York timezone.
+ * Tubafrenzy stores radioHour as epoch ms at the hour boundary in Eastern time.
+ *
+ * @param dateStr ISO date string (YYYY-MM-DD)
+ * @param hour Hour of day (0-23)
+ * @returns Epoch milliseconds for that hour in Eastern time
+ */
+export function computeRadioHourEpoch(dateStr: string, hour: number): number {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    hour: "2-digit",
+    hour12: false,
+  });
+
+  // Try EST (-5) then EDT (-4). One of these will produce the correct
+  // Eastern hour for the target date.
+  for (const offset of [5, 4]) {
+    const candidate = Date.UTC(y, m - 1, d, hour + offset, 0, 0, 0);
+    const etHour = parseInt(formatter.format(new Date(candidate)));
+    if (etHour === hour) {
+      return candidate;
+    }
+  }
+
+  // Fallback (shouldn't happen for America/New_York)
+  return Date.UTC(y, m - 1, d, hour + 5, 0, 0, 0);
+}
+
+/**
+ * Compute the offset in seconds of an entry within its radio hour.
+ *
+ * @param entryTimeCreated Entry's timeCreated in epoch ms
+ * @param radioHourEpoch Radio hour start in epoch ms
+ * @returns Seconds into the hour (clamped to [0, 3600])
+ */
+export function computeEntryOffsetSeconds(
+  entryTimeCreated: number,
+  radioHourEpoch: number
+): number {
+  const offsetMs = entryTimeCreated - radioHourEpoch;
+  const offsetSeconds = Math.floor(offsetMs / 1000);
+  return Math.max(0, Math.min(3600, offsetSeconds));
+}
+
 export function createTimestamp(
   date: Date,
   hour: number,


### PR DESCRIPTION
## Summary

- Add `GET /api/playlist?date=YYYY-MM-DD&hour=HH` route that fetches flowsheet entries from tubafrenzy, computes Eastern-timezone radioHour epoch ms, and maps entries with playhead offset seconds
- Add `usePlaylist` React hook with request abort on refetch, loading/error states
- Add `TubafrenzyEntry`, `ArchivePlaylistEntry`, `PlaylistResponse` types and `mapTubafrenzyEntry` mapper
- Add `computeRadioHourEpoch` (EST/EDT-aware) and `computeEntryOffsetSeconds` utilities
- Add `TUBAFRENZY_PROXY_URL` and `LIBRARY_METADATA_URL` env vars to `.env.example`

Closes #32

## Test plan

- [ ] `npm test` passes (166 tests, 11 files)
- [ ] `npx tsc --noEmit` has no new type errors (pre-existing errors in jwt-utils.test.ts only)
- [ ] After tubafrenzy PR merges ([WXYC/tubafrenzy#326](https://github.com/WXYC/tubafrenzy/pull/326)), verify `/api/playlist?date=YYYY-MM-DD&hour=HH` returns playlist data from dev server