### PR TITLE
Recognize simple-auth password server-side for signed-URL access

### DIFF
--- a/app/api/signed-url/__tests__/route.test.ts
+++ b/app/api/signed-url/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the JWT utils
 const mockVerifyAuthHeader = vi.fn();
@@ -298,6 +298,77 @@ describe("POST /api/signed-url", () => {
       await callRoute({ key });
 
       expect(mockVerifyAuthHeader).toHaveBeenCalledWith(null);
+    });
+  });
+
+  // The deployed bundle ships with NEXT_PUBLIC_AUTH_USERNAME/PASSWORD baked in,
+  // which puts every user on the simple-auth code path. That path doesn't
+  // produce a JWT, so without this bypass the server treats authenticated
+  // users as anonymous and refuses anything older than the public window.
+  describe("simple-auth bearer bypass", () => {
+    beforeEach(() => {
+      vi.stubEnv("NEXT_PUBLIC_AUTH_PASSWORD", "shared-archive-password");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    function keyForDaysAgo(daysAgo: number): string {
+      const date = new Date();
+      date.setDate(date.getDate() - daysAgo);
+      const year = date.getFullYear();
+      const month = (date.getMonth() + 1).toString().padStart(2, "0");
+      const day = date.getDate().toString().padStart(2, "0");
+      return `${year}/${month}/${day}/${year}${month}${day}1200.mp3`;
+    }
+
+    it("grants DJ-range access when Bearer token matches the configured simple-auth password", async () => {
+      const response = await callRoute(
+        { key: keyForDaysAgo(60) },
+        "Bearer shared-archive-password"
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.url).toBe("https://s3.example.com/signed-url");
+      expect(mockVerifyAuthHeader).not.toHaveBeenCalled();
+    });
+
+    it("still enforces the 90-day cap under simple-auth", async () => {
+      const response = await callRoute(
+        { key: keyForDaysAgo(100) },
+        "Bearer shared-archive-password"
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("falls back to JWT verification when Bearer token does not match", async () => {
+      mockVerifyAuthHeader.mockResolvedValue({
+        authenticated: false,
+        error: "Invalid signature",
+      });
+
+      const response = await callRoute(
+        { key: keyForDaysAgo(60) },
+        "Bearer some-other-token"
+      );
+
+      expect(response.status).toBe(403);
+      expect(mockVerifyAuthHeader).toHaveBeenCalledWith("Bearer some-other-token");
+    });
+
+    it("does not grant access when env var is empty, even if Bearer token is empty", async () => {
+      vi.stubEnv("NEXT_PUBLIC_AUTH_PASSWORD", "");
+      mockVerifyAuthHeader.mockResolvedValue({
+        authenticated: false,
+        error: "No authorization header",
+      });
+
+      const response = await callRoute({ key: keyForDaysAgo(60) }, "Bearer ");
+
+      expect(response.status).toBe(403);
     });
   });
 });

--- a/app/api/signed-url/__tests__/route.test.ts
+++ b/app/api/signed-url/__tests__/route.test.ts
@@ -307,6 +307,7 @@ describe("POST /api/signed-url", () => {
   // users as anonymous and refuses anything older than the public window.
   describe("simple-auth bearer bypass", () => {
     beforeEach(() => {
+      vi.stubEnv("NEXT_PUBLIC_AUTH_USERNAME", "wxycarch");
       vi.stubEnv("NEXT_PUBLIC_AUTH_PASSWORD", "shared-archive-password");
     });
 
@@ -370,5 +371,43 @@ describe("POST /api/signed-url", () => {
 
       expect(response.status).toBe(403);
     });
+
+    it("does not grant access when env var is set but USERNAME is missing (mirrors client useSimpleAuth)", async () => {
+      // PASSWORD is stubbed by the surrounding beforeEach. Explicitly clear
+      // USERNAME so the simple-auth pair is incomplete.
+      vi.stubEnv("NEXT_PUBLIC_AUTH_USERNAME", "");
+      mockVerifyAuthHeader.mockResolvedValue({
+        authenticated: false,
+        error: "Token verification failed",
+      });
+
+      const response = await callRoute(
+        { key: keyForDaysAgo(60) },
+        "Bearer shared-archive-password"
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it.each([
+      ["lowercase prefix", "bearer shared-archive-password"],
+      ["no space after Bearer", "Bearershared-archive-password"],
+      ["different scheme", "Token shared-archive-password"],
+    ])(
+      "does not match Bearer with %s",
+      async (_label, malformedHeader) => {
+        mockVerifyAuthHeader.mockResolvedValue({
+          authenticated: false,
+          error: "Invalid authorization format",
+        });
+
+        const response = await callRoute(
+          { key: keyForDaysAgo(60) },
+          malformedHeader
+        );
+
+        expect(response.status).toBe(403);
+      }
+    );
   });
 });

--- a/app/api/signed-url/route.ts
+++ b/app/api/signed-url/route.ts
@@ -52,13 +52,25 @@ export async function POST(request: Request) {
     parseInt(hour)
   );
 
-  // Verify JWT from Authorization header to determine access level
+  // Determine if user has DJ-level access. Two paths can grant it:
+  //   1. Simple-auth mode: the deployed bundle ships with a shared password
+  //      baked in (NEXT_PUBLIC_AUTH_PASSWORD). When the client is in that
+  //      mode it sends the password as the Bearer token, since better-auth
+  //      isn't producing a JWT for it.
+  //   2. Better-auth: a JWT with a DJ role claim.
   const authHeader = request.headers.get("Authorization");
-  const verifyResult = await verifyAuthHeader(authHeader);
+  const bearerToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : null;
+  const simpleAuthPassword = process.env.NEXT_PUBLIC_AUTH_PASSWORD;
+  const matchedSimpleAuth =
+    !!simpleAuthPassword && bearerToken === simpleAuthPassword;
 
-  // Determine if user has DJ-level access
-  const hasDJAccess =
-    verifyResult.authenticated && isDJRole(verifyResult.role);
+  let hasDJAccess = matchedSimpleAuth;
+  if (!hasDJAccess) {
+    const verifyResult = await verifyAuthHeader(authHeader);
+    hasDJAccess = verifyResult.authenticated && isDJRole(verifyResult.role);
+  }
 
   // Get appropriate date range based on authentication
   const config = hasDJAccess ? archiveConfigs.dj : archiveConfigs.default;

--- a/app/api/signed-url/route.ts
+++ b/app/api/signed-url/route.ts
@@ -56,15 +56,19 @@ export async function POST(request: Request) {
   //   1. Simple-auth mode: the deployed bundle ships with a shared password
   //      baked in (NEXT_PUBLIC_AUTH_PASSWORD). When the client is in that
   //      mode it sends the password as the Bearer token, since better-auth
-  //      isn't producing a JWT for it.
+  //      isn't producing a JWT for it. The bypass is only honored when both
+  //      env vars are configured — mirrors the client-side useSimpleAuth check.
   //   2. Better-auth: a JWT with a DJ role claim.
   const authHeader = request.headers.get("Authorization");
   const bearerToken = authHeader?.startsWith("Bearer ")
     ? authHeader.slice(7)
     : null;
-  const simpleAuthPassword = process.env.NEXT_PUBLIC_AUTH_PASSWORD;
+  const simpleAuthConfigured =
+    !!process.env.NEXT_PUBLIC_AUTH_USERNAME &&
+    !!process.env.NEXT_PUBLIC_AUTH_PASSWORD;
   const matchedSimpleAuth =
-    !!simpleAuthPassword && bearerToken === simpleAuthPassword;
+    simpleAuthConfigured &&
+    bearerToken === process.env.NEXT_PUBLIC_AUTH_PASSWORD;
 
   let hasDJAccess = matchedSimpleAuth;
   if (!hasDJAccess) {

--- a/lib/__tests__/auth.simple-auth.test.tsx
+++ b/lib/__tests__/auth.simple-auth.test.tsx
@@ -1,0 +1,139 @@
+// Covers the simple-auth code path in lib/auth.tsx. The `useSimpleAuth`
+// constant is evaluated at module load, so each test stubs the env vars,
+// resets the module registry, then dynamically imports the auth module.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// happy-dom v20 doesn't ship a localStorage by default; install an in-memory
+// shim so AuthProvider's simple-auth persistence path can run in tests.
+const memoryStore = new Map<string, string>();
+const memoryLocalStorage = {
+  getItem: (key: string) => memoryStore.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    memoryStore.set(key, value);
+  },
+  removeItem: (key: string) => {
+    memoryStore.delete(key);
+  },
+  clear: () => memoryStore.clear(),
+  key: (i: number) => Array.from(memoryStore.keys())[i] ?? null,
+  get length() {
+    return memoryStore.size;
+  },
+};
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: memoryLocalStorage,
+});
+Object.defineProperty(window, "localStorage", {
+  configurable: true,
+  value: memoryLocalStorage,
+});
+
+const mockGetSession = vi.fn();
+const mockGetJWTToken = vi.fn();
+
+vi.mock("@wxyc/shared/auth-client", () => ({
+  authClient: {
+    getSession: () => mockGetSession(),
+    signIn: { username: vi.fn(), email: vi.fn() },
+    signOut: vi.fn(),
+  },
+  getJWTToken: () => mockGetJWTToken(),
+  isDJRole: (role: string | null | undefined) =>
+    ["dj", "musicDirector", "stationManager"].includes(role as string),
+  DJ_ROLES: ["dj", "musicDirector", "stationManager"],
+}));
+
+const SIMPLE_USERNAME = "wxycarch";
+const SIMPLE_PASSWORD = "shared-archive-password";
+
+async function renderWithSimpleAuth() {
+  vi.stubEnv("NEXT_PUBLIC_AUTH_USERNAME", SIMPLE_USERNAME);
+  vi.stubEnv("NEXT_PUBLIC_AUTH_PASSWORD", SIMPLE_PASSWORD);
+  vi.resetModules();
+  const { AuthProvider, useAuth } = await import("../auth");
+
+  function TestComponent() {
+    const { isAuthenticated, getToken, login } = useAuth();
+    return (
+      <div>
+        <div data-testid="authenticated">
+          {isAuthenticated ? "yes" : "no"}
+        </div>
+        <button
+          onClick={async () => {
+            const result = await login(SIMPLE_USERNAME, SIMPLE_PASSWORD);
+            document.body.setAttribute(
+              "data-login",
+              result.success ? "ok" : result.error
+            );
+          }}
+        >
+          Login
+        </button>
+        <button
+          onClick={async () => {
+            const token = await getToken();
+            document.body.setAttribute("data-token", token ?? "null");
+          }}
+        >
+          Get Token
+        </button>
+      </div>
+    );
+  }
+
+  render(
+    <AuthProvider>
+      <TestComponent />
+    </AuthProvider>
+  );
+}
+
+describe("AuthProvider in simple-auth mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryStore.clear();
+    document.body.removeAttribute("data-login");
+    document.body.removeAttribute("data-token");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("starts unauthenticated when no simpleAuthed flag is set", async () => {
+    await renderWithSimpleAuth();
+    await waitFor(() => {
+      expect(screen.getByTestId("authenticated").textContent).toBe("no");
+    });
+  });
+
+  it("returns the shared password as the token after successful login", async () => {
+    const user = userEvent.setup();
+    await renderWithSimpleAuth();
+
+    await user.click(screen.getByText("Login"));
+    await waitFor(() => {
+      expect(document.body.getAttribute("data-login")).toBe("ok");
+    });
+
+    await user.click(screen.getByText("Get Token"));
+    await waitFor(() => {
+      expect(document.body.getAttribute("data-token")).toBe(SIMPLE_PASSWORD);
+    });
+  });
+
+  it("returns null when not simpleAuthed", async () => {
+    const user = userEvent.setup();
+    await renderWithSimpleAuth();
+
+    await user.click(screen.getByText("Get Token"));
+    await waitFor(() => {
+      expect(document.body.getAttribute("data-token")).toBe("null");
+    });
+  });
+});

--- a/lib/__tests__/auth.simple-auth.test.tsx
+++ b/lib/__tests__/auth.simple-auth.test.tsx
@@ -2,12 +2,22 @@
 // constant is evaluated at module load, so each test stubs the env vars,
 // resets the module registry, then dynamically imports the auth module.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// happy-dom v20 doesn't ship a localStorage by default; install an in-memory
-// shim so AuthProvider's simple-auth persistence path can run in tests.
+// happy-dom v20 doesn't ship a localStorage by default. Install an in-memory
+// shim only for the duration of this file so other test files (e.g. ones
+// asserting SSR-like absence of window.localStorage) aren't affected.
 const memoryStore = new Map<string, string>();
 const memoryLocalStorage = {
   getItem: (key: string) => memoryStore.get(key) ?? null,
@@ -23,14 +33,6 @@ const memoryLocalStorage = {
     return memoryStore.size;
   },
 };
-Object.defineProperty(globalThis, "localStorage", {
-  configurable: true,
-  value: memoryLocalStorage,
-});
-Object.defineProperty(window, "localStorage", {
-  configurable: true,
-  value: memoryLocalStorage,
-});
 
 const mockGetSession = vi.fn();
 const mockGetJWTToken = vi.fn();
@@ -94,6 +96,39 @@ async function renderWithSimpleAuth() {
 }
 
 describe("AuthProvider in simple-auth mode", () => {
+  const originalGlobalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+  const originalWindowLocalStorage = Object.getOwnPropertyDescriptor(
+    window,
+    "localStorage"
+  );
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryLocalStorage,
+    });
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: memoryLocalStorage,
+    });
+  });
+
+  afterAll(() => {
+    if (originalGlobalLocalStorage) {
+      Object.defineProperty(globalThis, "localStorage", originalGlobalLocalStorage);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+    if (originalWindowLocalStorage) {
+      Object.defineProperty(window, "localStorage", originalWindowLocalStorage);
+    } else {
+      delete (window as unknown as { localStorage?: unknown }).localStorage;
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     memoryStore.clear();
@@ -109,6 +144,19 @@ describe("AuthProvider in simple-auth mode", () => {
     await renderWithSimpleAuth();
     await waitFor(() => {
       expect(screen.getByTestId("authenticated").textContent).toBe("no");
+    });
+  });
+
+  it("transitions to authenticated after successful login", async () => {
+    const user = userEvent.setup();
+    await renderWithSimpleAuth();
+
+    expect(screen.getByTestId("authenticated").textContent).toBe("no");
+
+    await user.click(screen.getByText("Login"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("authenticated").textContent).toBe("yes");
     });
   });
 

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -163,10 +163,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const getToken = useCallback(async (): Promise<string | null> => {
-    if (useSimpleAuth) return null;
+    if (useSimpleAuth) {
+      // The server route recognizes the simple-auth password as a Bearer
+      // token and grants DJ-range access. Without this, simple-auth users
+      // see the 90-day calendar but the server refuses anything past the
+      // public window.
+      return simpleAuthed
+        ? (process.env.NEXT_PUBLIC_AUTH_PASSWORD ?? null)
+        : null;
+    }
     if (!session) return null;
     return getJWTToken();
-  }, [session]);
+  }, [session, simpleAuthed]);
 
   return (
     <AuthContext.Provider

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -167,10 +167,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // The server route recognizes the simple-auth password as a Bearer
       // token and grants DJ-range access. Without this, simple-auth users
       // see the 90-day calendar but the server refuses anything past the
-      // public window.
-      return simpleAuthed
-        ? (process.env.NEXT_PUBLIC_AUTH_PASSWORD ?? null)
-        : null;
+      // public window. `useSimpleAuth` already proves the env var is set.
+      return simpleAuthed ? process.env.NEXT_PUBLIC_AUTH_PASSWORD! : null;
     }
     if (!session) return null;
     return getJWTToken();


### PR DESCRIPTION
Closes #66

## Summary

- Client: in simple-auth mode, `getToken()` returns `NEXT_PUBLIC_AUTH_PASSWORD` when `simpleAuthed` instead of `null`, so the same shared credential rides along as the Bearer token to `/api/signed-url`.
- Server: `/api/signed-url` grants DJ-range access when the Bearer value matches `NEXT_PUBLIC_AUTH_PASSWORD` (when set), otherwise the existing JWT verification path runs unchanged.

The password is already exposed via `NEXT_PUBLIC_AUTH_PASSWORD` in the public bundle, so this doesn't introduce a new secret leak — it just plumbs the same shared credential through to the server boundary that was already enforcing access.

## Why

The deployed bundle ships with `NEXT_PUBLIC_AUTH_USERNAME` / `NEXT_PUBLIC_AUTH_PASSWORD` baked in (set as GitHub Actions vars). Every signed-in user goes through the simple-auth path, which never produced a JWT. The client UI exposed the 90-day calendar based on `isAuthenticated`, but the server fell through to the public 30-day window because no `Authorization` header arrived. The result: DJs saw a full 90 days in the picker but anything older than ~30 days returned 403, and the download button didn't render at all (it's gated on `audioUrl`). See #66 for the full trace.

## Test plan

- [x] Server: new `simple-auth bearer bypass` describe block in `app/api/signed-url/__tests__/route.test.ts` covering match → 200, > 90 days → 403, mismatch → falls back to JWT, empty env var → no access.
- [x] Client: new `lib/__tests__/auth.simple-auth.test.tsx` covering `getToken()` returning the password after login and `null` otherwise.
- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 340 / 340 pass.
- [ ] Manual smoke against the deployed worker once merged: sign in with the simple-auth credentials, confirm a date ~60 days back plays and the download button appears.