### PR TITLE
chore: ignore TypeScript semver-major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
         dependency-type: "development"
       production-dependencies:
         dependency-type: "production"
+    ignore:
+      # Hold TypeScript at v6: @wxyc/shared (peers ^5||^6) and typescript-eslint
+      # (peers <6.1) have no TS7-compatible release yet (checked 2026-07-16). A grouped
+      # major bump to typescript@7 fails `npm ci` with ERESOLVE before tests run. Lift
+      # this and upgrade TypeScript as a tracked change once the toolchain supports TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for `typescript` `version-update:semver-major` on the npm ecosystem.

## Why

TypeScript 7.0 (the native-compiler rewrite) is now npm `latest`, so Dependabot keeps bundling a `typescript` 6→7 major bump into the `dev-dependencies` group. That bump fails `npm ci` with `ERESOLVE` before any test runs, because the `@wxyc/shared` peer range (`^5 || ^6`) and `typescript-eslint` (peers `<6.1.0`) has no TS7-compatible release yet — verified 2026-07-16, where the latest **and** rc/canary channels of ts-jest, typescript-eslint, and openapi-typescript all still cap their `typescript` peer below 7. The one incompatible package fails the *entire* grouped PR, holding the other (fine) dev-dep bumps hostage.

Ignoring the semver-major typescript bump lets the rest of each grouped PR flow through green while TypeScript stays pinned at 6.x. Minor/patch bumps within 6.x are unaffected.

## When to lift

Once ts-jest, typescript-eslint, and openapi-typescript ship TS7-compatible releases, remove this ignore and do the TS7 upgrade as its own tracked, coordinated change across the repos.
