### PR TITLE
fix(deps): declare better-auth so @wxyc/shared/auth-client resolves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.10",
         "@wxyc/shared": "github:WXYC/wxyc-shared",
+        "better-auth": "^1.6.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
@@ -1466,7 +1467,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.20.tgz",
       "integrity": "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
@@ -1496,7 +1496,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.20.tgz",
       "integrity": "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2",
@@ -1513,7 +1512,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.20.tgz",
       "integrity": "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2",
@@ -1530,7 +1528,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.20.tgz",
       "integrity": "sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2"
@@ -1541,7 +1538,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.20.tgz",
       "integrity": "sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2",
@@ -1558,7 +1554,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.20.tgz",
       "integrity": "sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2",
@@ -1579,7 +1574,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.20.tgz",
       "integrity": "sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@better-auth/core": "^1.6.20",
         "@better-auth/utils": "0.4.2",
@@ -1591,7 +1585,6 @@
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
       "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       }
@@ -1600,8 +1593,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
       "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
@@ -3191,7 +3183,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
       "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -3231,7 +3222,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -3586,7 +3576,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6984,12 +6973,11 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.12.0",
-      "resolved": "git+ssh://git@github.com/WXYC/wxyc-shared.git#27a165843d087362719e1d88b262665af8efe18f",
-      "integrity": "sha512-ycUtHm/VngL1Hl2aObS3mlQOcf2T7/pRRUBIpGJQxkcsGxjkuFnWfug53GRtfbY7FEwVa8Mu1IScEkPriDL04Q==",
+      "version": "2.0.0",
+      "resolved": "git+ssh://git@github.com/WXYC/wxyc-shared.git#867d35f41fc459aff20422718644c19e08b03ddf",
       "license": "MIT",
       "dependencies": {
-        "date-fns": "^4.1.0"
+        "date-fns": "^4.4.0"
       },
       "engines": {
         "node": ">=24"
@@ -6997,6 +6985,11 @@
       "peerDependencies": {
         "better-auth": "^1.5.0",
         "typescript": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "better-auth": {
+          "optional": true
+        }
       }
     },
     "node_modules/abort-controller": {
@@ -7458,7 +7451,6 @@
       "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.20.tgz",
       "integrity": "sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/core": "1.6.20",
         "@better-auth/drizzle-adapter": "1.6.20",
@@ -7564,7 +7556,6 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.6.tgz",
       "integrity": "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -8240,8 +8231,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/del": {
       "version": "5.1.0",
@@ -11040,7 +11030,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
       "integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.0.0"
       }
@@ -11911,7 +11900,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -13164,8 +13152,7 @@
       "version": "0.7.12",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
       "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -13357,8 +13344,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.10",
     "@wxyc/shared": "github:WXYC/wxyc-shared",
+    "better-auth": "^1.6.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",


### PR DESCRIPTION
## Problem

`next build` fails with `Module not found: Can't resolve 'better-auth/react'` (and `better-auth/client/plugins`) as soon as any `npm install` re-resolves the unpinned `github:WXYC/wxyc-shared` git dependency forward to a v2 commit. This is what broke Dependabot PR #83 (its lockfile regeneration rolled `@wxyc/shared` from a pre-v2 pin to v2).

## Root cause

archive imports `@wxyc/shared/auth-client`, whose shipped `dist/auth-client/index.js` does an unconditional top-level `import { createAuthClient } from 'better-auth/react'`. As of **`@wxyc/shared` v2.0.0**, `better-auth` is an **optional peer dependency** (`peerDependenciesMeta.better-auth.optional = true`) rather than a regular dependency — so every consumer of the auth-client entry must now declare `better-auth` itself. dj-site already does (`better-auth: ^1.6.20`); archive never did. archive only kept building because its lockfile happened to pin a pre-v2 `@wxyc/shared` commit where `better-auth` was still installed transitively. The moment the unpinned git dep rolls to v2, `better-auth` drops out of the install tree and the auth-client import can't resolve.

`main` is green today only because its lockfile hasn't been regenerated since v2 landed. Any future `npm install` — this PR or otherwise — trips the same wire.

## Fix

Declare `better-auth` (`^1.6.20`, matching dj-site) in archive's own `dependencies`, so the auth-client imports resolve regardless of which `@wxyc/shared` commit the git dep lands on. This commit also advances the pinned `@wxyc/shared` to the current v2 head, so the lockfile is a verified-good state rather than a stale pre-v2 pin that silently breaks on the next install. The lockfile net-shrinks: v2 drops the server-side adapters (drizzle/kysely/mongo/prisma) that v1 pulled in transitively, while the direct `better-auth` dep pulls only the client surface archive needs.

## Verification

Reproduced the failure at the v2 state (`@wxyc/shared` @ `867d35f4`, the commit #83 rolls to) and confirmed the fix there:
- `npm run build` — compiles, static pages generated
- `tsc --noEmit` — clean
- `vitest run` — 345/345 pass

## Follow-ups

- Unblocks **#83**: after this merges, `@dependabot rebase` on #83 picks up the declared peer and goes green.
- The deeper fragility — archive tracks `@wxyc/shared` via an unpinned `github:` URL, which is how a *major* (v2.0.0) breaking change landed with zero review — is tracked separately (structural pinning issue, filed alongside this PR).
- See also #18 (auth-pattern alignment).