### PR TITLE
fix: send the LML_API_KEY bearer on artwork lookups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ BETTER_AUTH_JWKS_URL=https://api.wxyc.org/auth/jwks
 # Playlist data sources (server-side only)
 TUBAFRENZY_PROXY_URL=https://wxyc-proxy-production.up.railway.app/playlists
 LIBRARY_METADATA_URL=https://library-metadata-lookup-production.up.railway.app/api/v1
+# Bearer token for library-metadata-lookup (same LML_API_KEY shared by
+# Backend-Service, request-o-matic, and tubafrenzy). Without it, artwork
+# lookups get 401s from prod LML and pages silently show no artwork.
+LML_API_KEY=
 
 # Analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ See `.env.example`. Key variables:
 - `BETTER_AUTH_URL` -- server-side auth proxy destination (used by next.config.ts rewrites)
 - `NEXT_PUBLIC_BETTER_AUTH_URL` -- client-side auth URL (baked into bundle)
 - `BETTER_AUTH_JWKS_URL` -- JWKS endpoint for JWT verification
+- `LML_API_KEY` -- bearer token for library-metadata-lookup artwork enrichment (org-wide shared key; LML returns 401 without it and artwork lookups silently come back empty)
 
 ## Testing
 
@@ -101,7 +102,7 @@ GitHub Actions workflow (`.github/workflows/deploy.yml`):
 1. **test** job: `npm ci`, `tsc --noEmit`, `npm test`
 2. **build-and-deploy** job: OpenNext build, then `wrangler deploy` on push to `main`
 
-Runtime secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BETTER_AUTH_JWKS_URL`, etc.) are set on the Cloudflare Worker directly, not in GitHub.
+Runtime secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `BETTER_AUTH_JWKS_URL`, `LML_API_KEY`, etc.) are set on the Cloudflare Worker directly, not in GitHub.
 
 ## Code Conventions
 

--- a/app/api/artwork/__tests__/route.test.ts
+++ b/app/api/artwork/__tests__/route.test.ts
@@ -4,11 +4,13 @@ import { POST } from "../route";
 const mockFetch = vi.fn();
 
 beforeEach(() => {
+  mockFetch.mockReset();
   global.fetch = mockFetch;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function makeRequest(body: Record<string, string>) {
@@ -119,6 +121,40 @@ describe("POST /api/artwork", () => {
     expect(data.artworkUrl).toBeNull();
 
     consoleSpy.mockRestore();
+  });
+
+  it("sends the LML_API_KEY bearer to library-metadata-lookup", async () => {
+    vi.stubEnv("LML_API_KEY", "test-lml-key");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    });
+
+    await POST(makeRequest({ artist: "Juana Molina", album: "DOGA" }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/lookup"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-lml-key",
+        }),
+      })
+    );
+  });
+
+  it("omits the Authorization header when LML_API_KEY is unset", async () => {
+    vi.stubEnv("LML_API_KEY", "");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    });
+
+    await POST(makeRequest({ artist: "Juana Molina", album: "DOGA" }));
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty("Authorization");
   });
 
   it("accepts artist-only lookup", async () => {

--- a/app/api/artwork/route.ts
+++ b/app/api/artwork/route.ts
@@ -59,10 +59,17 @@ export async function POST(request: Request) {
     );
   }
 
+  // Read at request time: on Cloudflare Workers, process.env is populated per
+  // request, so a module-scope read can miss the secret on cold start.
+  const lmlApiKey = process.env.LML_API_KEY;
+
   try {
     const lookupResponse = await fetch(`${LIBRARY_METADATA_URL}/lookup`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(lmlApiKey ? { Authorization: `Bearer ${lmlApiKey}` } : {}),
+      },
       body: JSON.stringify({
         artist: artist || undefined,
         album: album || undefined,


### PR DESCRIPTION
Closes #92

## What

Sends the `LML_API_KEY` bearer on artwork lookups to library-metadata-lookup. The route had no Authorization header — it predates LML's auth, and the 2026-04-26 key rollout ([library-metadata-lookup@6de9584](https://github.com/WXYC/library-metadata-lookup/commit/6de95842dd85dc3f9cfbfcb57ed506b7445b5d6f)) missed this app — so every lookup has 401'd since, and because the route swallows non-2xx responses, archive pages have silently shown no artwork, genre, or streaming links for ~3 months.

## How

- `app/api/artwork/route.ts` reads `process.env.LML_API_KEY` inside the request handler (per-request read — a module-scope read can miss the runtime environment on cold start) and sends `Authorization: Bearer <key>`. When the key is unset (local dev against an auth-disabled LML), the header is omitted entirely rather than sending `Bearer undefined`.
- Tests cover both paths; also added `mockFetch.mockReset()` in `beforeEach` so call assertions don't leak across tests.
- `LML_API_KEY` documented in `.env.example` and `CLAUDE.md`.

## Deploy order

`deploy.yml` auto-deploys on push to `main`, so the Worker secret had to exist before merge. **Done**: `LML_API_KEY` was uploaded to the `wxyc-archive` Worker on 2026-07-20 via `wrangler secret put` (same shared key the other LML consumers use). Merging this PR is now sufficient to ship the fix.

## Verification

- `npx tsc --noEmit` clean, 347/347 vitest tests pass.
- eslint currently crashes repo-wide on `main` (ESLint 10 vs the `eslint-plugin-react` bundled in `eslint-config-next`) — pre-existing, filed separately; CI does not run lint, so CI is unaffected.
- Post-merge check: `POST /api/artwork` with a known artist/album returns non-null fields.
