### PR TITLE
fix: gate DJ archive access on JWT station role, not session.user.role

### DIFF
--- a/lib/__tests__/auth.test.tsx
+++ b/lib/__tests__/auth.test.tsx
@@ -27,6 +27,18 @@ vi.mock("@wxyc/shared/auth-client", () => ({
   DJ_ROLES: ["dj", "musicDirector", "stationManager"],
 }));
 
+// Build a realistic (unsigned) JWT string whose payload decodes via jose's
+// decodeJwt. The signature segment is not verified client-side, so any
+// placeholder works here.
+function b64url(obj: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const header = { alg: "RS256", typ: "JWT" };
+  return `${b64url(header)}.${b64url(payload)}.sig`;
+}
+
 // Test component that uses the auth hook
 function TestComponent() {
   const {
@@ -107,13 +119,16 @@ describe("AuthProvider", () => {
       });
     });
 
-    it("should populate session when user is logged in", async () => {
+    it("should authenticate a plain DJ whose session.user.role is null but whose JWT station role is dj", async () => {
+      // This mirrors production: the admin-plugin `user.role` is null for a
+      // plain dj, and the real station role only lives in the JWT claim.
       mockGetSession.mockResolvedValue({
         data: {
           session: { id: "session-1" },
-          user: { id: "user-1", name: "Test DJ", role: "dj" },
+          user: { id: "user-1", name: "Test DJ", role: null },
         },
       });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
 
       render(
         <AuthProvider>
@@ -130,13 +145,41 @@ describe("AuthProvider", () => {
       });
     });
 
-    it("should not be authenticated without DJ role", async () => {
+    it("should authenticate a stationManager whose session.user.role is the admin-plugin role but whose JWT station role is stationManager", async () => {
       mockGetSession.mockResolvedValue({
         data: {
           session: { id: "session-1" },
-          user: { id: "user-1", name: "Member", role: "member" },
+          user: { id: "user-1", name: "Station Manager", role: "admin" },
         },
       });
+      mockGetJWTToken.mockResolvedValue(
+        fakeJwt({ sub: "user-1", role: "stationManager" })
+      );
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user-role").textContent).toBe(
+          "stationManager"
+        );
+        expect(screen.getByTestId("authenticated").textContent).toBe(
+          "authenticated"
+        );
+      });
+    });
+
+    it("should not be authenticated for a non-DJ member with a member JWT role", async () => {
+      mockGetSession.mockResolvedValue({
+        data: {
+          session: { id: "session-1" },
+          user: { id: "user-1", name: "Member", role: null },
+        },
+      });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "member" }));
 
       render(
         <AuthProvider>
@@ -149,6 +192,63 @@ describe("AuthProvider", () => {
           "not-authenticated"
         );
       });
+    });
+
+    it("should not be authenticated when there is no JWT token", async () => {
+      mockGetSession.mockResolvedValue({
+        data: {
+          session: { id: "session-1" },
+          user: { id: "user-1", name: "Member", role: null },
+        },
+      });
+      mockGetJWTToken.mockResolvedValue(null);
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated").textContent).toBe(
+          "not-authenticated"
+        );
+      });
+    });
+
+    it("should not be authenticated when the JWT is malformed and cannot be decoded", async () => {
+      // Fail closed: a token that decodeJwt cannot parse yields no station
+      // role, so the user is never treated as a DJ.
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockGetSession.mockResolvedValue({
+        data: {
+          session: { id: "session-1" },
+          user: { id: "user-1", name: "Test DJ", role: null },
+        },
+      });
+      mockGetJWTToken.mockResolvedValue("not-a-jwt");
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated").textContent).toBe(
+          "not-authenticated"
+        );
+      });
+      // Confirm the fail-closed path ran via the decode catch, not merely the
+      // default null state.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to decode JWT for station role:",
+        expect.anything()
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -172,9 +272,10 @@ describe("AuthProvider", () => {
       mockGetSession.mockResolvedValue({
         data: {
           session: { id: "session-1" },
-          user: { id: "user-1", name: "Test DJ", role: "dj" },
+          user: { id: "user-1", name: "Test DJ", role: null },
         },
       });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
 
       await user.click(screen.getByText("Login"));
 
@@ -186,17 +287,50 @@ describe("AuthProvider", () => {
       });
     });
 
-    it("should return success on successful login", async () => {
+    it("should return success for a DJ with session.user.role null but JWT role dj", async () => {
       const user = userEvent.setup();
       mockGetSession
         .mockResolvedValueOnce({ data: null })
         .mockResolvedValueOnce({
           data: {
             session: { id: "session-1" },
-            user: { id: "user-1", name: "Test DJ", role: "dj" },
+            user: { id: "user-1", name: "Test DJ", role: null },
           },
         });
       mockSignInUsername.mockResolvedValue({ error: null });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("ready");
+      });
+
+      await user.click(screen.getByText("Login"));
+
+      await waitFor(() => {
+        expect(document.body.getAttribute("data-login-result")).toBe("success");
+      });
+    });
+
+    it("should return success for a stationManager with session.user.role admin but JWT role stationManager", async () => {
+      const user = userEvent.setup();
+      mockGetSession
+        .mockResolvedValueOnce({ data: null })
+        .mockResolvedValueOnce({
+          data: {
+            session: { id: "session-1" },
+            user: { id: "user-1", name: "Station Manager", role: "admin" },
+          },
+        });
+      mockSignInUsername.mockResolvedValue({ error: null });
+      mockGetJWTToken.mockResolvedValue(
+        fakeJwt({ sub: "user-1", role: "stationManager" })
+      );
 
       render(
         <AuthProvider>
@@ -241,17 +375,50 @@ describe("AuthProvider", () => {
       });
     });
 
-    it("should return error when user lacks DJ role", async () => {
+    it("should return error when the JWT station role is not a DJ role", async () => {
       const user = userEvent.setup();
       mockGetSession
         .mockResolvedValueOnce({ data: null })
         .mockResolvedValueOnce({
           data: {
             session: { id: "session-1" },
-            user: { id: "user-1", name: "Member", role: "member" },
+            user: { id: "user-1", name: "Member", role: null },
           },
         });
       mockSignInUsername.mockResolvedValue({ error: null });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "member" }));
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("ready");
+      });
+
+      await user.click(screen.getByText("Login"));
+
+      await waitFor(() => {
+        expect(document.body.getAttribute("data-login-result")).toBe(
+          "Your account does not have archive access"
+        );
+      });
+    });
+
+    it("should return error when no JWT token is available after login", async () => {
+      const user = userEvent.setup();
+      mockGetSession
+        .mockResolvedValueOnce({ data: null })
+        .mockResolvedValueOnce({
+          data: {
+            session: { id: "session-1" },
+            user: { id: "user-1", name: "Member", role: null },
+          },
+        });
+      mockSignInUsername.mockResolvedValue({ error: null });
+      mockGetJWTToken.mockResolvedValue(null);
 
       render(
         <AuthProvider>
@@ -279,9 +446,10 @@ describe("AuthProvider", () => {
       mockGetSession.mockResolvedValue({
         data: {
           session: { id: "session-1" },
-          user: { id: "user-1", name: "Test DJ", role: "dj" },
+          user: { id: "user-1", name: "Test DJ", role: null },
         },
       });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
       mockSignOut.mockResolvedValue({});
 
       render(
@@ -331,10 +499,10 @@ describe("AuthProvider", () => {
       mockGetSession.mockResolvedValue({
         data: {
           session: { id: "session-1" },
-          user: { id: "user-1", name: "Test DJ", role: "dj" },
+          user: { id: "user-1", name: "Test DJ", role: null },
         },
       });
-      mockGetJWTToken.mockResolvedValue("jwt-token-123");
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
 
       render(
         <AuthProvider>
@@ -349,7 +517,9 @@ describe("AuthProvider", () => {
       await user.click(screen.getByText("Get Token"));
 
       await waitFor(() => {
-        expect(document.body.getAttribute("data-token")).toBe("jwt-token-123");
+        expect(document.body.getAttribute("data-token")).toBe(
+          fakeJwt({ sub: "user-1", role: "dj" })
+        );
       });
     });
   });

--- a/lib/__tests__/auth.test.tsx
+++ b/lib/__tests__/auth.test.tsx
@@ -241,14 +241,40 @@ describe("AuthProvider", () => {
           "not-authenticated"
         );
       });
-      // Confirm the fail-closed path ran via the decode catch, not merely the
-      // default null state.
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Failed to decode JWT for station role:",
-        expect.anything()
-      );
+      // Confirm the fail-closed path ran via the decode catch (an error was
+      // logged), not merely the default null state. We assert only that the
+      // decode failure was surfaced, not the exact wording, so rewording the
+      // log message doesn't break a still-correct implementation.
+      expect(consoleErrorSpy).toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
+    });
+
+    it("should not be authenticated when the JWT is already expired", async () => {
+      // A decodable but expired token must not grant access off the stale
+      // role claim; the server would reject it anyway.
+      mockGetSession.mockResolvedValue({
+        data: {
+          session: { id: "session-1" },
+          user: { id: "user-1", name: "Test DJ", role: null },
+        },
+      });
+      // exp is seconds since the epoch; 1 is 1970, far in the past.
+      mockGetJWTToken.mockResolvedValue(
+        fakeJwt({ sub: "user-1", role: "dj", exp: 1 })
+      );
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated").textContent).toBe(
+          "not-authenticated"
+        );
+      });
     });
   });
 
@@ -407,14 +433,16 @@ describe("AuthProvider", () => {
       });
     });
 
-    it("should return error when no JWT token is available after login", async () => {
+    it("should report a transient failure (not 'no access') when no JWT token is available after login", async () => {
+      // A DJ whose token endpoint is momentarily unavailable must not be told
+      // they lack access — that's the exact wrong message this fix removes.
       const user = userEvent.setup();
       mockGetSession
         .mockResolvedValueOnce({ data: null })
         .mockResolvedValueOnce({
           data: {
             session: { id: "session-1" },
-            user: { id: "user-1", name: "Member", role: null },
+            user: { id: "user-1", name: "Test DJ", role: null },
           },
         });
       mockSignInUsername.mockResolvedValue({ error: null });
@@ -434,7 +462,7 @@ describe("AuthProvider", () => {
 
       await waitFor(() => {
         expect(document.body.getAttribute("data-login-result")).toBe(
-          "Your account does not have archive access"
+          "Could not verify your archive access. Please try again."
         );
       });
     });
@@ -521,6 +549,41 @@ describe("AuthProvider", () => {
           fakeJwt({ sub: "user-1", role: "dj" })
         );
       });
+    });
+
+    it("should reuse the JWT fetched during session resolution without re-fetching", async () => {
+      const user = userEvent.setup();
+      mockGetSession.mockResolvedValue({
+        data: {
+          session: { id: "session-1" },
+          user: { id: "user-1", name: "Test DJ", role: null },
+        },
+      });
+      mockGetJWTToken.mockResolvedValue(fakeJwt({ sub: "user-1", role: "dj" }));
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      // Once authenticated, the token fetched to resolve the station role is
+      // cached, so getToken must not hit the token endpoint again.
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated").textContent).toBe(
+          "authenticated"
+        );
+      });
+
+      mockGetJWTToken.mockClear();
+      await user.click(screen.getByText("Get Token"));
+
+      await waitFor(() => {
+        expect(document.body.getAttribute("data-token")).toBe(
+          fakeJwt({ sub: "user-1", role: "dj" })
+        );
+      });
+      expect(mockGetJWTToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from "react";
 import {
   authClient,
@@ -16,7 +17,11 @@ import {
 import type { Session } from "@wxyc/shared/auth-client";
 import { decodeJwt } from "jose";
 
-// Extended user type with custom role field
+// Extended user type. NOTE: `role` here is the better-auth admin-plugin role
+// (null for a plain dj, "admin" for elevated accounts), NOT the WXYC station
+// role. Do not gate archive access on it — use the JWT station role resolved
+// by fetchStationRole instead (see the userRole field on the context, which
+// exposes that station role).
 type User = {
   id: string;
   name: string;
@@ -47,6 +52,26 @@ const useSimpleAuth =
   !!process.env.NEXT_PUBLIC_AUTH_USERNAME &&
   !!process.env.NEXT_PUBLIC_AUTH_PASSWORD;
 
+// Tolerance for client/server clock skew when treating a decoded JWT as
+// expired. We only discard a token that is expired by more than this, so a
+// slightly fast client clock never logs out a DJ who is holding a token the
+// server would still accept.
+const JWT_CLOCK_SKEW_MS = 60_000;
+
+// Result of resolving the station role from the JWT. `"unavailable"` means we
+// could not determine a role at all — no token, a token-fetch or decode
+// failure, or an expired token. That is a transient/system condition, distinct
+// from a user who successfully decoded to a non-DJ role. Callers fail closed on
+// both but report them differently.
+type StationRoleResult =
+  | {
+      status: "ok";
+      role: string | null;
+      token: string;
+      expiresAt: number | null;
+    }
+  | { status: "unavailable" };
+
 /**
  * Resolve the WXYC station role (dj, musicDirector, stationManager, member,
  * ...) from the better-auth JWT `role` claim. This is distinct from
@@ -54,17 +79,34 @@ const useSimpleAuth =
  * null for plain DJs. The JWT is decoded client-side without signature
  * verification purely to gate UI state; the server independently re-verifies
  * the JWT (see lib/jwt-utils.ts) before honoring any download request.
+ *
+ * Never throws: any failure to fetch or decode the token yields
+ * `{ status: "unavailable" }` so the UI fails closed.
  */
-async function fetchStationRole(): Promise<string | null> {
-  const token = await getJWTToken();
-  if (!token) return null;
+async function fetchStationRole(): Promise<StationRoleResult> {
+  let token: string | null;
+  try {
+    token = await getJWTToken();
+  } catch (error) {
+    console.error("Failed to fetch JWT for station role:", error);
+    return { status: "unavailable" };
+  }
+  if (!token) return { status: "unavailable" };
 
   try {
     const payload = decodeJwt(token);
-    return (payload.role as string) ?? null;
+    const expiresAt =
+      typeof payload.exp === "number" ? payload.exp * 1000 : null;
+    if (expiresAt !== null && expiresAt + JWT_CLOCK_SKEW_MS < Date.now()) {
+      // Already expired; the server would reject it, so don't treat the user
+      // as authenticated off a stale token.
+      return { status: "unavailable" };
+    }
+    const role = typeof payload.role === "string" ? payload.role : null;
+    return { status: "ok", role, token, expiresAt };
   } catch (error) {
     console.error("Failed to decode JWT for station role:", error);
-    return null;
+    return { status: "unavailable" };
   }
 }
 
@@ -75,8 +117,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [simpleAuthed, setSimpleAuthed] = useState(false);
   const [stationRole, setStationRole] = useState<string | null>(null);
 
-  const userRole = stationRole;
+  // Cache the JWT fetched while resolving the station role so getToken() can
+  // reuse it instead of issuing another /auth/token round-trip on every
+  // download. Cleared on logout and whenever the role becomes unavailable.
+  const tokenCacheRef = useRef<{
+    value: string;
+    expiresAt: number | null;
+  } | null>(null);
+
   const isAuthenticated = useSimpleAuth ? simpleAuthed : isDJRole(stationRole);
+
+  // Resolve the station role, then sync both the gating state and the token
+  // cache. Returns the result so callers can distinguish "not a DJ" from
+  // "couldn't determine access".
+  const resolveStationRole =
+    useCallback(async (): Promise<StationRoleResult> => {
+      const result = await fetchStationRole();
+      if (result.status === "ok") {
+        setStationRole(result.role);
+        tokenCacheRef.current = {
+          value: result.token,
+          expiresAt: result.expiresAt,
+        };
+      } else {
+        setStationRole(null);
+        tokenCacheRef.current = null;
+      }
+      return result;
+    }, []);
 
   // Check session on mount
   useEffect(() => {
@@ -92,7 +160,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (data?.session && data?.user) {
           setSession(data.session);
           setUser(data.user as User);
-          setStationRole(await fetchStationRole());
+          await resolveStationRole();
         }
       } catch (error) {
         console.error("Failed to check session:", error);
@@ -102,7 +170,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     checkSession();
-  }, []);
+  }, [resolveStationRole]);
 
   const login = useCallback(
     async (usernameOrEmail: string, password: string): Promise<LoginResult> => {
@@ -141,16 +209,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const sessionResult = await authClient.getSession();
         if (sessionResult.data?.session && sessionResult.data?.user) {
           setSession(sessionResult.data.session);
-          const userData = sessionResult.data.user as User;
-          setUser(userData);
+          setUser(sessionResult.data.user as User);
 
           // Gate on the WXYC station role from the JWT claim, not the
           // admin-plugin session.user.role (null for a plain dj). See
           // fetchStationRole above; mirrors the server signed-url gate.
-          const role = await fetchStationRole();
-          setStationRole(role);
+          const roleResult = await resolveStationRole();
 
-          if (!isDJRole(role)) {
+          if (roleResult.status !== "ok") {
+            // We couldn't fetch or decode the token — a transient/system
+            // failure, not an authorization decision. Don't tell a DJ they
+            // lack access when we simply couldn't check.
+            return {
+              success: false,
+              error: "Could not verify your archive access. Please try again.",
+            };
+          }
+
+          if (!isDJRole(roleResult.role)) {
             return {
               success: false,
               error: "Your account does not have archive access",
@@ -169,7 +245,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         };
       }
     },
-    []
+    [resolveStationRole]
   );
 
   const logout = useCallback(async () => {
@@ -187,6 +263,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(null);
       setUser(null);
       setStationRole(null);
+      tokenCacheRef.current = null;
     }
   }, []);
 
@@ -199,6 +276,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return simpleAuthed ? process.env.NEXT_PUBLIC_AUTH_PASSWORD! : null;
     }
     if (!session) return null;
+
+    // Reuse the JWT already fetched while resolving the station role, unless
+    // it is within the clock-skew window of expiring. This avoids a redundant
+    // /auth/token round-trip on the download hot path.
+    const cached = tokenCacheRef.current;
+    if (
+      cached &&
+      (cached.expiresAt === null ||
+        cached.expiresAt - JWT_CLOCK_SKEW_MS > Date.now())
+    ) {
+      return cached.value;
+    }
     return getJWTToken();
   }, [session, simpleAuthed]);
 
@@ -209,7 +298,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuthenticated,
         session,
         user,
-        userRole,
+        userRole: stationRole,
         login,
         logout,
         getToken,

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -14,6 +14,7 @@ import {
   DJ_ROLES,
 } from "@wxyc/shared/auth-client";
 import type { Session } from "@wxyc/shared/auth-client";
+import { decodeJwt } from "jose";
 
 // Extended user type with custom role field
 type User = {
@@ -46,16 +47,36 @@ const useSimpleAuth =
   !!process.env.NEXT_PUBLIC_AUTH_USERNAME &&
   !!process.env.NEXT_PUBLIC_AUTH_PASSWORD;
 
+/**
+ * Resolve the WXYC station role (dj, musicDirector, stationManager, member,
+ * ...) from the better-auth JWT `role` claim. This is distinct from
+ * `session.user.role`, which is the better-auth admin-plugin role and is
+ * null for plain DJs. The JWT is decoded client-side without signature
+ * verification purely to gate UI state; the server independently re-verifies
+ * the JWT (see lib/jwt-utils.ts) before honoring any download request.
+ */
+async function fetchStationRole(): Promise<string | null> {
+  const token = await getJWTToken();
+  if (!token) return null;
+
+  try {
+    const payload = decodeJwt(token);
+    return (payload.role as string) ?? null;
+  } catch (error) {
+    console.error("Failed to decode JWT for station role:", error);
+    return null;
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [simpleAuthed, setSimpleAuthed] = useState(false);
+  const [stationRole, setStationRole] = useState<string | null>(null);
 
-  const userRole = user?.role ?? null;
-  const isAuthenticated = useSimpleAuth
-    ? simpleAuthed
-    : isDJRole(userRole);
+  const userRole = stationRole;
+  const isAuthenticated = useSimpleAuth ? simpleAuthed : isDJRole(stationRole);
 
   // Check session on mount
   useEffect(() => {
@@ -71,6 +92,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (data?.session && data?.user) {
           setSession(data.session);
           setUser(data.user as User);
+          setStationRole(await fetchStationRole());
         }
       } catch (error) {
         console.error("Failed to check session:", error);
@@ -122,8 +144,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           const userData = sessionResult.data.user as User;
           setUser(userData);
 
-          // Check if user has DJ role
-          if (!isDJRole(userData.role)) {
+          // Gate on the WXYC station role from the JWT claim, not the
+          // admin-plugin session.user.role (null for a plain dj). See
+          // fetchStationRole above; mirrors the server signed-url gate.
+          const role = await fetchStationRole();
+          setStationRole(role);
+
+          if (!isDJRole(role)) {
             return {
               success: false,
               error: "Your account does not have archive access",
@@ -159,6 +186,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setSession(null);
       setUser(null);
+      setStationRole(null);
     }
   }, []);
 


### PR DESCRIPTION
## Problem

DJs could sign in to archive.wxyc.org with valid dj.wxyc.org credentials but were immediately told "Your account does not have archive access", and never saw the Download affordance. This affected essentially every DJ.

## Root cause

The client-side access gate in `lib/auth.tsx` (better-auth path) derived DJ access from `session.user.role`. That field is the better-auth **admin-plugin** role — `null` for a plain `dj`, and `"admin"` (not a `DJ_ROLES` value) for stationManager/admin/owner. The actual WXYC **station role** (`dj`, `musicDirector`, `stationManager`) only lives in the better-auth **JWT `role` claim**, populated from the org member role. So `isDJRole(session.user.role)` was `false` for every DJ.

The server-side download gate already did the right thing: `app/api/signed-url/route.ts` verifies the JWT and gates on `isDJRole(verifyResult.role)` (the JWT claim). So the server would have authorized a DJ — the client just never let them past sign-in, and the Download button (rendered only when `isAuthenticated && audioUrl`) never appeared.

## Fix

Derive DJ access from the JWT `role` claim, consistent with the server gate. Added `fetchStationRole()`, which calls `getJWTToken()` (`GET /auth/token`) and decodes the returned JWT client-side with `jose.decodeJwt` (no signature verification — this only gates UI state; the server independently re-verifies the JWT before honoring any download). The resolved value is tracked in `stationRole` state, populated after the initial session check and after a successful login; `isAuthenticated`, `userRole`, and the login DJ-role check now read it instead of `session.user.role`. Fail-closed: no token, a malformed token, or a missing `role` claim yields `null` → not authenticated.

The change is confined to the better-auth branch; the `useSimpleAuth` shared-credential fallback is untouched.

## Testing

`lib/__tests__/auth.test.tsx` now exercises realistic session shapes — a plain DJ whose `session.user.role` is `null` but whose JWT `role` claim is `"dj"` (the exact case the old code broke on), a stationManager whose `user.role` is `"admin"` but JWT role is `stationManager`, a non-DJ member, a missing token, and a malformed token (asserting the fail-closed decode path actually runs). Tests use the real `jose.decodeJwt`, not a mock. Full suite: 352 passing; `npx tsc --noEmit` clean (the two checks CI runs).

## Notes

- #18 ("Upgrade auth patterns…") as scoped would swap `isDJRole()` for `roleToAuthorization()` but keep sourcing the role from `user.role`; it would not fix this bug. Whoever picks it up must keep the role **source** as the JWT/org role.
- Repo-wide `npm run lint` is currently broken (ESLint 10 vs the `eslint-plugin-react` bundled in eslint-config-next 16), unrelated to this change and not run by CI. Tracked in #101.

Closes #100
